### PR TITLE
docs: add page and hook descriptions

### DIFF
--- a/client/src/components/school/tabs/GuidesTab.tsx
+++ b/client/src/components/school/tabs/GuidesTab.tsx
@@ -1,3 +1,8 @@
+/**
+ * Guides tab manages assignments of Wildflower guides to the school. Rows in
+ * an AG Grid list guide name, type, dates, and active status with inline
+ * editing and deletion actions.
+ */
 import React from 'react';
 import type { GuideAssignment } from '@shared/schema';
 import { GridBase } from '@/components/shared/GridBase';

--- a/client/src/components/school/tabs/LocationsTab.tsx
+++ b/client/src/components/school/tabs/LocationsTab.tsx
@@ -1,3 +1,8 @@
+/**
+ * Locations tab tracks historical and current addresses for a school. An AG
+ * Grid provides inline editing for address fields, current flags, and start/end
+ * dates, with save and delete actions per row.
+ */
 import React from 'react';
 import type { Location } from '@shared/schema';
 import { GridBase } from '@/components/shared/GridBase';

--- a/client/src/components/school/tabs/SummaryTab.tsx
+++ b/client/src/components/school/tabs/SummaryTab.tsx
@@ -1,3 +1,8 @@
+/**
+ * Summary tab for a school detail page. Highlights key school information
+ * such as logos, governance, age levels, membership, and an "about" section,
+ * along with map coordinates and other entity cards.
+ */
 import React, { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { EntityCard } from '@/components/shared/EntityCard';

--- a/client/src/components/teacher/tabs/CertsTab.tsx
+++ b/client/src/components/teacher/tabs/CertsTab.tsx
@@ -1,3 +1,7 @@
+/**
+ * Certifications tab surfaces the educator's Montessori certification records
+ * through the `MontessoriCertificationsTable` component.
+ */
 import { MontessoriCertificationsTable } from "@/components/montessori-certifications-table";
 
 export function CertsTab({ educatorId }: { educatorId: string }) {

--- a/client/src/components/teacher/tabs/ContactTab.tsx
+++ b/client/src/components/teacher/tabs/ContactTab.tsx
@@ -1,3 +1,8 @@
+/**
+ * Contact tab provides email, phone, and address information for the educator.
+ * Email addresses are managed via `EmailAddressesTable` while other fields are
+ * rendered using `EntityCard` within a detail grid layout.
+ */
 import { TableCard } from "@/components/shared/TableCard";
 import { EmailAddressesTable } from "@/components/email-addresses-table";
 import { DetailGrid } from "@/components/shared/DetailGrid";

--- a/client/src/components/teacher/tabs/CultivationTab.tsx
+++ b/client/src/components/teacher/tabs/CultivationTab.tsx
@@ -1,3 +1,8 @@
+/**
+ * Cultivation tab summarizes early outreach data for a prospective teacher.
+ * It references SSJ Fillout forms to show the most recent submission date and
+ * displays partner assignments and interest notes.
+ */
 import type { SSJFilloutForm, Teacher } from "@shared/schema";
 
 function mostRecentFilloutDate(ssjForms: SSJFilloutForm[]) {

--- a/client/src/components/teacher/tabs/DemographicsTab.tsx
+++ b/client/src/components/teacher/tabs/DemographicsTab.tsx
@@ -1,3 +1,7 @@
+/**
+ * Demographics tab lays out gender, pronouns, background, and language fields
+ * for the educator in grouped entity cards.
+ */
 import { DetailGrid } from "@/components/shared/DetailGrid";
 import { EntityCard } from "@/components/shared/EntityCard";
 import type { Teacher } from "@shared/schema";

--- a/client/src/components/teacher/tabs/EventsTab.tsx
+++ b/client/src/components/teacher/tabs/EventsTab.tsx
@@ -1,3 +1,7 @@
+/**
+ * Events tab shows the educator's participation in events, rendering
+ * `EventAttendanceTable` which handles data retrieval and display.
+ */
 import { EventAttendanceTable } from "@/components/event-attendance-table";
 
 export function EventsTab({ educatorId }: { educatorId: string }) {

--- a/client/src/components/teacher/tabs/LinkedTab.tsx
+++ b/client/src/components/teacher/tabs/LinkedTab.tsx
@@ -1,3 +1,7 @@
+/**
+ * Linked tab displays whether the educator is connected to external systems
+ * like Holaspirit or Teacher Credentials and shows related identifiers.
+ */
 import type { Teacher } from "@shared/schema";
 
 export function LinkedTab({ teacher }: { teacher: Teacher }) {

--- a/client/src/components/teacher/tabs/NotesTab.tsx
+++ b/client/src/components/teacher/tabs/NotesTab.tsx
@@ -1,3 +1,7 @@
+/**
+ * Notes tab lists and edits free‑form notes linked to the educator. The
+ * `EducatorNotesTable` component handles fetching, sorting, and persistence.
+ */
 import { EducatorNotesTable } from "@/components/educator-notes-table";
 
 export function NotesTab({ educatorId }: { educatorId: string }) {

--- a/client/src/components/teacher/tabs/OnlineFormsTab.tsx
+++ b/client/src/components/teacher/tabs/OnlineFormsTab.tsx
@@ -1,3 +1,8 @@
+/**
+ * Online Forms tab lists SSJ Fillout form submissions for the educator. It
+ * fetches forms with React Query, derives the most recent submission date, and
+ * renders the results in `SSJFilloutFormsTable`.
+ */
 import { SSJFilloutFormsTable } from "@/components/ssj-fillout-forms-table";
 import { useQuery } from "@tanstack/react-query";
 import type { SSJFilloutForm } from "@shared/schema";

--- a/client/src/components/teacher/tabs/SchoolsTab.tsx
+++ b/client/src/components/teacher/tabs/SchoolsTab.tsx
@@ -1,3 +1,8 @@
+/**
+ * Schools tab for teacher detail. Renders the educator's school association
+ * records using `EducatorSchoolAssociationsTable`, which manages fetching and
+ * editing of associated schools.
+ */
 import { EducatorSchoolAssociationsTable } from "@/components/educator-school-associations-table";
 
 export function SchoolsTab({ educatorId }: { educatorId: string }) {

--- a/client/src/components/teacher/tabs/SummaryTab.tsx
+++ b/client/src/components/teacher/tabs/SummaryTab.tsx
@@ -1,3 +1,8 @@
+/**
+ * Summary tab for the teacher detail page. Presents a quick snapshot of
+ * educator basics, education and certification status, and current school
+ * connection using simple fields and colored status badges.
+ */
 import { Badge } from "@/components/ui/badge";
 import { getStatusColor } from "@/lib/utils";
 import type { Teacher } from "@shared/schema";

--- a/client/src/hooks/use-aggrid-features.ts
+++ b/client/src/hooks/use-aggrid-features.ts
@@ -1,3 +1,8 @@
+/**
+ * Hook that exposes whether AG Grid enterprise modules have been loaded and
+ * provides the appropriate text filter type. It polls until enterprise features
+ * are ready so grids can safely reference set filters.
+ */
 import { useEffect, useState } from "react";
 import { isAgGridEnterpriseEnabled } from "@/lib/ag-grid-enterprise";
 

--- a/client/src/hooks/use-api-query.ts
+++ b/client/src/hooks/use-api-query.ts
@@ -1,5 +1,8 @@
-// Custom hook for consistent API data fetching with error handling
-
+/**
+ * Utility hooks wrapping React Query for standardized API calls and mutations
+ * with typed error handling. Exposes `useApiQuery` and `useApiMutation` helpers
+ * that automatically include credentials and parse error responses.
+ */
 import { useQuery, useMutation, type UseQueryOptions, type UseMutationOptions } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
 import { getErrorMessage } from "@shared/utils";

--- a/client/src/hooks/use-cached-data.ts
+++ b/client/src/hooks/use-cached-data.ts
@@ -1,3 +1,9 @@
+/**
+ * Collection of React Query helpers for caching and prefetching common
+ * datasets (educators, schools, charters, and detail/subtable records). These
+ * hooks centralize caching strategy and expose convenience prefetch methods for
+ * hover interactions.
+ */
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 

--- a/client/src/hooks/use-mobile.tsx
+++ b/client/src/hooks/use-mobile.tsx
@@ -1,3 +1,7 @@
+/**
+ * Hook to detect whether the viewport is below the mobile breakpoint. Returns
+ * a boolean updated via a media query listener.
+ */
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768

--- a/client/src/hooks/use-table-refresh.ts
+++ b/client/src/hooks/use-table-refresh.ts
@@ -1,10 +1,11 @@
+/**
+ * Hook to force periodic refetching of React Query tables when their queries
+ * have been invalidated, ensuring grid views reflect recent mutations.
+ * Returns a manual `refreshTables` helper.
+ */
 import { useEffect } from 'react';
 import { queryClient } from '@/lib/queryClient';
 
-/**
- * Custom hook to ensure table data refreshes after mutations
- * This solves the persistent issue of tables not updating after record creation
- */
 export function useTableRefresh(queryKeys: string[], dependencies: any[] = []) {
   useEffect(() => {
     // Set up an interval to periodically check for stale data

--- a/client/src/hooks/use-test-mode-toast.ts
+++ b/client/src/hooks/use-test-mode-toast.ts
@@ -1,3 +1,8 @@
+/**
+ * Helper hook that displays contextual toasts when the application is in test
+ * mode. Provides functions to show success or warning messages instead of
+ * executing real operations.
+ */
 import { useToast } from '@/hooks/use-toast';
 import { getTestMode } from '@/components/TestModeToggle';
 

--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -1,3 +1,8 @@
+/**
+ * Internal toast state management used by the UI toast component. Provides
+ * hooks and reducer logic for showing, updating, and dismissing toasts with a
+ * small queue and long removal delay.
+ */
 import * as React from "react"
 
 import type {

--- a/client/src/pages/ach-setup-complete.tsx
+++ b/client/src/pages/ach-setup-complete.tsx
@@ -1,3 +1,7 @@
+/**
+ * Confirmation page shown after a borrower completes ACH setup. Provides a
+ * summary of next steps and links back to the loan dashboard.
+ */
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CheckCircle, ArrowRight, Shield, CreditCard } from "lucide-react";

--- a/client/src/pages/ach-setup.tsx
+++ b/client/src/pages/ach-setup.tsx
@@ -1,3 +1,8 @@
+/**
+ * ACH setup page for loan borrowers. Collects bank account information and
+ * authorization, creates a Stripe ACH payment method, and updates the server.
+ * On success it redirects to a confirmation page.
+ */
 import { useState, useEffect } from "react";
 import { useLocation } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";

--- a/client/src/pages/charter-detail.tsx
+++ b/client/src/pages/charter-detail.tsx
@@ -1,3 +1,10 @@
+/**
+ * Charter detail page. Fetches a single charter record and presents multiple
+ * tabs showing related schools, roles, educator associations, applications,
+ * authorizer contacts, reports, assessments, governance documents, 990 filings,
+ * notes, and action steps. Tabs primarily render specialized table components
+ * for each dataset.
+ */
 import { useParams } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";

--- a/client/src/pages/charters.tsx
+++ b/client/src/pages/charters.tsx
@@ -1,3 +1,9 @@
+/**
+ * Charters page lists charter organizations in an AG Grid with search and
+ * optional user scoping. Data is fetched via React Query and filtered by the
+ * global search term and "My records" toggle. It hooks into the page title and
+ * exposes an "Add New" option for creating charters.
+ */
 import { useQuery } from "@tanstack/react-query";
 import { AgGridReact } from "ag-grid-react";
 import type { ColDef } from "ag-grid-community";

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,3 +1,10 @@
+/**
+ * Dashboard landing page that summarizes upcoming action steps and recently
+ * related schools for the selected user. It fetches action step and school
+ * data via React Query, applies relative date helpers for due statuses, and
+ * wires the global "Add New" menu to creation modals for teachers and schools.
+ * Cards and lists link out to respective detail pages.
+ */
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/src/pages/google-sync.tsx
+++ b/client/src/pages/google-sync.tsx
@@ -1,3 +1,7 @@
+/**
+ * Entry point for the optional Google Sync dashboard. Simply renders the
+ * `GoogleSyncDashboard` component which manages Gmail and Calendar sync status.
+ */
 import React from 'react';
 import { GoogleSyncDashboard } from '@/components/google/GoogleSyncDashboard';
 

--- a/client/src/pages/loan-detail.tsx
+++ b/client/src/pages/loan-detail.tsx
@@ -1,3 +1,9 @@
+/**
+ * Loan detail page loads a single loan (with borrower info) and displays
+ * summary metrics and several tabs for timeline, payments, documents, and
+ * related entities. Utilizes React Query for fetching and formats currency and
+ * dates for readability.
+ */
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, Link } from "wouter";
@@ -7,11 +13,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { 
+import {
   ArrowLeft,
-  DollarSign, 
-  Calendar, 
-  TrendingUp, 
+  DollarSign,
+  Calendar,
+  TrendingUp,
   Building2,
   MapPin,
   Users,

--- a/client/src/pages/loan-origination.tsx
+++ b/client/src/pages/loan-origination.tsx
@@ -1,3 +1,8 @@
+/**
+ * Loan origination pipeline page. Shows each loan's progress through steps
+ * like promissory note signing, ACH setup, and fund distribution, highlighting
+ * next required actions.
+ */
 import { useQuery } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/client/src/pages/loans.tsx
+++ b/client/src/pages/loans.tsx
@@ -1,3 +1,8 @@
+/**
+ * Loans page provides a multi-tab interface for loan summary metrics, loan
+ * lists, applications, payments, and document tracking. It allows creating
+ * loan applications via a dialog and toggling between card and table views.
+ */
 import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { usePageTitle } from "@/App";

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,3 +1,7 @@
+/**
+ * Login page initiating Supabase Google SSO. Redirects authenticated users to
+ * the home page and otherwise displays a single "Continue with Google" button.
+ */
 import { useEffect } from 'react';
 import { useAuth } from '@/contexts/auth-context';
 import { Button } from '@/components/ui/button';

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,3 +1,7 @@
+/**
+ * Fallback page for unmatched routes. Shows a simple 404 message prompting
+ * developers to ensure the route is registered.
+ */
 import { Card, CardContent } from "@/components/ui/card";
 import { AlertCircle } from "lucide-react";
 

--- a/client/src/pages/reset.tsx
+++ b/client/src/pages/reset.tsx
@@ -1,3 +1,8 @@
+/**
+ * Password reset page used after Supabase sends a recovery link. Parses tokens
+ * from the URL hash, allows the user to enter a new password, updates the
+ * Supabase session, and redirects to the login page on success.
+ */
 import React, { useEffect, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';

--- a/client/src/pages/school-detail.tsx
+++ b/client/src/pages/school-detail.tsx
@@ -1,3 +1,9 @@
+/**
+ * School detail view. Fetches a school record and supports editing of core
+ * fields, locations, guides, notes, and related entities. The page includes
+ * tabs (Summary, Locations, Guides) rendered from `components/school/tabs` and
+ * integrates modals for assigning educators or creating records.
+ */
 import { useParams } from "wouter";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";

--- a/client/src/pages/schools.tsx
+++ b/client/src/pages/schools.tsx
@@ -1,3 +1,10 @@
+/**
+ * Lists schools in a searchable grid and wires the header's "Add New" control
+ * to open a creation modal. Records are fetched with `useCachedSchools` and
+ * filtered client-side by the global search term and the optional user filter
+ * which restricts to schools guided or assigned to the current user. Debug
+ * logging tracks filtered counts and grid state.
+ */
 import { useState, useEffect } from "react";
 import SchoolsGrid from "@/components/schools-grid";
 import AddSchoolModal from "@/components/add-school-modal";

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,3 +1,8 @@
+/**
+ * User settings page. Currently offers a button to trigger a Supabase password
+ * reset email and placeholders for future appearance and notification settings.
+ * Sets the page title on mount and shows the signed‑in user's email.
+ */
 import { useEffect, useState } from "react";
 import { usePageTitle } from "@/App";
 import { Button } from "@/components/ui/button";

--- a/client/src/pages/teacher-detail.tsx
+++ b/client/src/pages/teacher-detail.tsx
@@ -1,3 +1,10 @@
+/**
+ * Teacher detail view. Loads a single educator record and presents multiple
+ * tabs (summary, schools, forms, certifications, events, notes, linked
+ * systems). Each tab delegates to a component under `components/teacher/tabs`.
+ * The page supports editing of educator details via React Query mutation and
+ * invalidates cached queries on save.
+ */
 import { useParams } from "wouter";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useEffect, useState } from "react";

--- a/client/src/pages/teachers.tsx
+++ b/client/src/pages/teachers.tsx
@@ -1,3 +1,10 @@
+/**
+ * Displays all educator records in an AG Grid table with text search and
+ * optional user scoping. Data is loaded via `useCachedEducators`, then
+ * filtered on the client by the global search box and the "My records" toggle
+ * from `useUserFilter`. The page registers "Add New" options to open a modal
+ * for creating a teacher and prefetches detail records as rows are hovered.
+ */
 import TeachersGrid from "@/components/teachers-grid";
 import { type Teacher } from "@shared/schema";
 import { useSearch } from "@/contexts/search-context";


### PR DESCRIPTION
## Summary
- document page components with expected behavior, data flow, and filters
- add plain-English explanations to teacher and school tab components
- describe custom hooks for data caching and utilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in server/simple-storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e3d7ada88321a302dff0213f5f3e