### PR TITLE
docs: expand file descriptions

### DIFF
--- a/client/src/components/school/tabs/GuidesTab.tsx
+++ b/client/src/components/school/tabs/GuidesTab.tsx
@@ -1,3 +1,16 @@
+/**
+ * School “Guides” tab. It accepts an array of guide assignment records and
+ * renders them in an AG‑Grid table. Each row shows the guide’s short name,
+ * assignment type, start/end dates, and whether the assignment is currently
+ * active. Every cell is filterable and sortable. Actions in the last column
+ * allow inline editing of a single row at a time: clicking “Edit” switches the
+ * row into draft mode where dates are edited via `DateInputInline` components
+ * and type/active fields are editable through the `drafts` state. “Save” passes
+ * the draft to `onUpdate` and clears editing state; “Cancel” reverts the draft;
+ * “Delete” invokes `onDelete`. Row height is fixed by `DEFAULT_GRID_PROPS` and
+ * grid behavior (auto height, no single‑click edit, etc.) is specified in
+ * `gridProps` so a new engineer can recreate the grid exactly.
+ */
 import React from 'react';
 import type { GuideAssignment } from '@shared/schema';
 import { GridBase } from '@/components/shared/GridBase';

--- a/client/src/components/school/tabs/LocationsTab.tsx
+++ b/client/src/components/school/tabs/LocationsTab.tsx
@@ -1,3 +1,14 @@
+/**
+ * School “Locations” tab. Receives an array of location records and displays
+ * them in an AG‑Grid table. Each row represents a physical or mailing address
+ * with flags for whether it is currently active as the physical or mailing
+ * address. The grid allows full inline editing: clicking the edit action turns
+ * the row into an editable form where address text, yes/no flags, and start/end
+ * dates can be changed. Saves call `onUpdate` with the row id and updated
+ * fields; deletes call `onDelete`. Filters and sorting are enabled for every
+ * column so history can be searched, and row height/behavior mirrors
+ * `DEFAULT_GRID_PROPS` to match other grids.
+ */
 import React from 'react';
 import type { Location } from '@shared/schema';
 import { GridBase } from '@/components/shared/GridBase';

--- a/client/src/components/school/tabs/SummaryTab.tsx
+++ b/client/src/components/school/tabs/SummaryTab.tsx
@@ -1,3 +1,17 @@
+/**
+ * School “Summary” tab. This is the landing view when opening a school detail.
+ * The top card shows branding: the school logo (several possible Airtable
+ * fields are checked), the full and short name, governance model, ages served,
+ * open date, and membership status. If the Airtable `about` or
+ * `aboutSpanish` fields are populated, an About/Descripción toggle is rendered
+ * allowing language switching without leaving the page. Below the hero card a
+ * `DetailGrid` organizes read‑only `EntityCard` sections for a map, contact
+ * information, and leadership. The map uses the school’s active latitude and
+ * longitude and falls back to the active physical address when coordinates are
+ * missing. Contact info lists phone, email, and website (hyperlinked). The
+ * leadership card lists founders and current teacher leaders. Everything in this
+ * tab is display‑only; there is no editing or server interaction here.
+ */
 import React, { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { EntityCard } from '@/components/shared/EntityCard';

--- a/client/src/components/teacher/tabs/CertsTab.tsx
+++ b/client/src/components/teacher/tabs/CertsTab.tsx
@@ -1,3 +1,11 @@
+/**
+ * Educator “Certifications” tab. A thin wrapper that renders the
+ * `MontessoriCertificationsTable` for the current educator. That table queries
+ * the server for all Montessori certification entries linked to the educator
+ * id and supports adding, editing, and deleting rows. This tab itself adds only
+ * spacing but establishes the contract that certifications are scoped by
+ * `educatorId` supplied via props.
+ */
 import { MontessoriCertificationsTable } from "@/components/montessori-certifications-table";
 
 export function CertsTab({ educatorId }: { educatorId: string }) {

--- a/client/src/components/teacher/tabs/ContactTab.tsx
+++ b/client/src/components/teacher/tabs/ContactTab.tsx
@@ -1,3 +1,13 @@
+/**
+ * Educator “Contact” tab. Displays all communication channels for the teacher.
+ * The first card is an `EmailAddressesTable` tied to the educator id which lets
+ * users add or remove multiple email addresses with inline actions. Beneath it a
+ * `DetailGrid` renders an `EntityCard` titled “Phone & Address” with three
+ * read‑write fields: primary phone, secondary phone, and home address. Values are
+ * passed directly from the `teacher` object and saved back through the card’s
+ * built‑in editing controls. The layout uses two columns so phone numbers sit
+ * side by side above the multiline address field.
+ */
 import { TableCard } from "@/components/shared/TableCard";
 import { EmailAddressesTable } from "@/components/email-addresses-table";
 import { DetailGrid } from "@/components/shared/DetailGrid";

--- a/client/src/components/teacher/tabs/CultivationTab.tsx
+++ b/client/src/components/teacher/tabs/CultivationTab.tsx
@@ -1,3 +1,13 @@
+/**
+ * Educator “Cultivation” tab. Used primarily for prospects, it aggregates data
+ * from initial interest forms and partner outreach. The tab shows the date of the
+ * most recent SSJ Fillout form submission by scanning all provided `ssjForms`.
+ * Additional fields pulled from the teacher record include source of contact,
+ * stated interests, assigned partner, meeting preferences, support types needed,
+ * routing information, one‑on‑one scheduling status, and whether a personal email
+ * was sent. All content is read‑only, organized in three responsive columns so
+ * staff can quickly gauge the prospect’s current state.
+ */
 import type { SSJFilloutForm, Teacher } from "@shared/schema";
 
 function mostRecentFilloutDate(ssjForms: SSJFilloutForm[]) {

--- a/client/src/components/teacher/tabs/DemographicsTab.tsx
+++ b/client/src/components/teacher/tabs/DemographicsTab.tsx
@@ -1,3 +1,11 @@
+/**
+ * Educator “Demographics” tab. Groups demographic information into several
+ * `EntityCard` sections within a `DetailGrid`. Sections cover gender identity,
+ * pronouns, racial/ethnic background (including LGBTQIA flag), and language &
+ * education. Array fields are joined with commas for readability. All fields are
+ * editable via the `EntityCard` component which handles saving changes back to
+ * the teacher record.
+ */
 import { DetailGrid } from "@/components/shared/DetailGrid";
 import { EntityCard } from "@/components/shared/EntityCard";
 import type { Teacher } from "@shared/schema";

--- a/client/src/components/teacher/tabs/EventsTab.tsx
+++ b/client/src/components/teacher/tabs/EventsTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Educator “Events” tab. Delegates to `EventAttendanceTable` which fetches and
+ * lists all event attendance records for the given educator id. The table shows
+ * each event’s name, date, and attendance status and supports adding or removing
+ * attendance entries. This tab merely provides spacing and wires through the
+ * educator id prop.
+ */
 import { EventAttendanceTable } from "@/components/event-attendance-table";
 
 export function EventsTab({ educatorId }: { educatorId: string }) {

--- a/client/src/components/teacher/tabs/LinkedTab.tsx
+++ b/client/src/components/teacher/tabs/LinkedTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Educator “Linked” tab. Summarizes connections to external systems. Current
+ * fields include a boolean for whether the educator has an active Holaspirit
+ * account, the Holaspirit member id, and the Teacher Credentials (TC) user id.
+ * The tab renders these values in a simple two‑column layout and does not allow
+ * editing; it is purely informational for cross‑system audits.
+ */
 import type { Teacher } from "@shared/schema";
 
 export function LinkedTab({ teacher }: { teacher: Teacher }) {

--- a/client/src/components/teacher/tabs/NotesTab.tsx
+++ b/client/src/components/teacher/tabs/NotesTab.tsx
@@ -1,3 +1,9 @@
+/**
+ * Educator “Notes” tab. Wraps the `EducatorNotesTable` which loads all note
+ * entries tied to the educator id. The table provides chronological sorting,
+ * inline editing, and add/delete actions so staff can maintain a running log of
+ * interactions. This tab itself supplies only layout spacing.
+ */
 import { EducatorNotesTable } from "@/components/educator-notes-table";
 
 export function NotesTab({ educatorId }: { educatorId: string }) {

--- a/client/src/components/teacher/tabs/OnlineFormsTab.tsx
+++ b/client/src/components/teacher/tabs/OnlineFormsTab.tsx
@@ -1,3 +1,10 @@
+/**
+ * Educator “Online Forms” tab. Uses React Query to fetch all SSJ Fillout form
+ * submissions for the given educator id. Before rendering the table it computes
+ * the most recent submission date for quick reference. The tab shows that date
+ * above an `SSJFilloutFormsTable` which presents each submission and supports
+ * viewing form details. Loading state is handled by React Query’s `isLoading`.
+ */
 import { SSJFilloutFormsTable } from "@/components/ssj-fillout-forms-table";
 import { useQuery } from "@tanstack/react-query";
 import type { SSJFilloutForm } from "@shared/schema";

--- a/client/src/components/teacher/tabs/SchoolsTab.tsx
+++ b/client/src/components/teacher/tabs/SchoolsTab.tsx
@@ -1,3 +1,11 @@
+/**
+ * Educator “Schools” tab. Hosts the `EducatorSchoolAssociationsTable` which
+ * lists all school association records for the given educator id. The table
+ * supports adding new associations, editing fields such as role and stage, and
+ * deleting existing links. It is the authoritative view of where an educator is
+ * or has been placed. This tab provides spacing but defers all heavy lifting to
+ * the table component.
+ */
 import { EducatorSchoolAssociationsTable } from "@/components/educator-school-associations-table";
 
 export function SchoolsTab({ educatorId }: { educatorId: string }) {

--- a/client/src/components/teacher/tabs/SummaryTab.tsx
+++ b/client/src/components/teacher/tabs/SummaryTab.tsx
@@ -1,3 +1,11 @@
+/**
+ * Educator “Summary” tab. A snapshot view composed of three cards: basic info
+ * (name, current role, discovery status), education & certification (currently
+ * only a Montessori certified yes/no badge), and school connection (whether the
+ * educator is active at a school, the name of the school, and the
+ * stage/status). Badges are colored via `getStatusColor` for quick visual cues.
+ * All data is read from the `teacher` object and displayed read‑only.
+ */
 import { Badge } from "@/components/ui/badge";
 import { getStatusColor } from "@/lib/utils";
 import type { Teacher } from "@shared/schema";

--- a/client/src/hooks/use-aggrid-features.ts
+++ b/client/src/hooks/use-aggrid-features.ts
@@ -1,3 +1,12 @@
+/**
+ * Determines whether the AG Grid enterprise modules have finished registering
+ * on the page. The hook polls `isAgGridEnterpriseEnabled` until it returns true
+ * and then exposes two pieces of state: `entReady` for components that need to
+ * know when enterprise features are usable, and `filterForText` which resolves
+ * to `agSetColumnFilter` when enterprise is ready or falls back to
+ * `agTextColumnFilter` otherwise. This ensures components can reference set
+ * filters without causing runtime errors in environments without a license.
+ */
 import { useEffect, useState } from "react";
 import { isAgGridEnterpriseEnabled } from "@/lib/ag-grid-enterprise";
 

--- a/client/src/hooks/use-api-query.ts
+++ b/client/src/hooks/use-api-query.ts
@@ -1,5 +1,12 @@
-// Custom hook for consistent API data fetching with error handling
-
+/**
+ * Wrapper around React Query that standardizes how the app talks to the Express
+ * API. `useApiQuery` performs GET requests with `credentials: 'include'`, parses
+ * error payloads, and sets default cache times (5‑minute stale, 10‑minute gc).
+ * `useApiMutation` generalizes POST/PUT/PATCH/DELETE calls, automatically
+ * serializing the body and returning JSON when present. Both helpers surface
+ * typed `ApiError`s so callers can rely on `message`, `statusCode`, and `code`.
+ * The file also exports `invalidateQueries` to manually bust caches by key.
+ */
 import { useQuery, useMutation, type UseQueryOptions, type UseMutationOptions } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient";
 import { getErrorMessage } from "@shared/utils";

--- a/client/src/hooks/use-cached-data.ts
+++ b/client/src/hooks/use-cached-data.ts
@@ -1,3 +1,13 @@
+/**
+ * Centralized cache helpers built on React Query. The hooks here fetch and cache
+ * high‑traffic datasets (teachers, schools, charters) with long stale times so
+ * repeated navigation stays snappy. `useCachedEducators` and `useCachedSchools`
+ * additionally expose `prefetchEducator`/`prefetchSchool` functions to warm up
+ * detail queries on hover. `useCachedDetail` and `useCachedSubtable` provide a
+ * consistent pattern for detail pages and nested tables with appropriate cache
+ * durations. Using these hooks keeps data fetching strategy uniform across the
+ * app.
+ */
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 

--- a/client/src/hooks/use-mobile.tsx
+++ b/client/src/hooks/use-mobile.tsx
@@ -1,3 +1,9 @@
+/**
+ * Watches the viewport width and reports whether it falls below the app’s
+ * mobile breakpoint (768px). A `matchMedia` listener keeps the `isMobile` state
+ * in sync on resize. Components can call `useIsMobile()` to switch layouts
+ * responsively without directly querying window size.
+ */
 import * as React from "react"
 
 const MOBILE_BREAKPOINT = 768

--- a/client/src/hooks/use-table-refresh.ts
+++ b/client/src/hooks/use-table-refresh.ts
@@ -1,10 +1,14 @@
+/**
+ * Keeps AG‑Grid views in sync after mutations. `useTableRefresh` accepts an
+ * array of query keys and sets up a 1‑second interval that checks whether each
+ * query has been invalidated in React Query; if so, it triggers a refetch. It
+ * also returns a `refreshTables` function that forces invalidation and refetch
+ * immediately. `refreshSchoolData` is a helper that targets all queries related
+ * to a specific school id.
+ */
 import { useEffect } from 'react';
 import { queryClient } from '@/lib/queryClient';
 
-/**
- * Custom hook to ensure table data refreshes after mutations
- * This solves the persistent issue of tables not updating after record creation
- */
 export function useTableRefresh(queryKeys: string[], dependencies: any[] = []) {
   useEffect(() => {
     // Set up an interval to periodically check for stale data

--- a/client/src/hooks/use-test-mode-toast.ts
+++ b/client/src/hooks/use-test-mode-toast.ts
@@ -1,3 +1,10 @@
+/**
+ * Shows orange “test mode” toasts in place of real operations. The returned
+ * `showTestModeSuccess` and `showTestModeWarning` helpers check the global test
+ * mode flag (via `getTestMode`). If enabled they emit contextual toast messages
+ * and return `true` so callers can bypass actual network calls. In production
+ * they no‑op and return `false`.
+ */
 import { useToast } from '@/hooks/use-toast';
 import { getTestMode } from '@/components/TestModeToggle';
 

--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -1,3 +1,11 @@
+/**
+ * Minimal toast manager used by the shadcn‑styled toast component. Maintains a
+ * global queue (limit 1) with manual reducer logic for add/update/dismiss. Each
+ * toast auto‑closes by dispatching `REMOVE_TOAST` after a long delay, and
+ * callers receive a handle with `dismiss` and `update` helpers. `useToast`
+ * subscribes React components to the internal state so they can render the UI
+ * and trigger dismissal.
+ */
 import * as React from "react"
 
 import type {

--- a/client/src/pages/ach-setup-complete.tsx
+++ b/client/src/pages/ach-setup-complete.tsx
@@ -1,3 +1,10 @@
+/**
+ * Standalone confirmation screen displayed after a borrower finishes entering
+ * bank info for ACH payments. It shows a success icon, outlines the three-step
+ * follow‑up process (verification deposits, fund distribution, automatic
+ * payments), lists payment method details, and offers navigation back to the
+ * loan dashboard or main app. No data is fetched; everything is static copy.
+ */
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CheckCircle, ArrowRight, Shield, CreditCard } from "lucide-react";

--- a/client/src/pages/ach-setup.tsx
+++ b/client/src/pages/ach-setup.tsx
@@ -1,3 +1,12 @@
+/**
+ * Borrower-facing form to connect a bank account for automatic loan payments.
+ * It loads basic loan info, collects routing/account numbers and authorization
+ * checkboxes, creates a Stripe `us_bank_account` payment method, and posts the
+ * resulting id to the server via `/api/loans/:id/ach-setup`. React Hook Form +
+ * zod handle validation. Success shows a toast, invalidates the loan query, and
+ * navigates to `/ach-setup-complete`; failure shows an error toast. Includes
+ * loading and “loan not found” states.
+ */
 import { useState, useEffect } from "react";
 import { useLocation } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";

--- a/client/src/pages/charter-detail.tsx
+++ b/client/src/pages/charter-detail.tsx
@@ -1,3 +1,13 @@
+/**
+ * Full detail view for a charter organization. Fetches the charter by id and
+ * sets the app header to include the charter’s short name. The page is tabbed:
+ * summary information in a static grid, plus child tabs for startup process,
+ * sites, staff roles, educator associations, applications, contract documents,
+ * authorizer contacts, reports, assessments, governance docs, 990 filings,
+ * notes/action steps, and emails/meetings. Each tab mounts a specialized table
+ * component responsible for its own CRUD operations. No “Add New” options are
+ * registered from this page.
+ */
 import { useParams } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";

--- a/client/src/pages/charters.tsx
+++ b/client/src/pages/charters.tsx
@@ -1,3 +1,11 @@
+/**
+ * Lists charter organizations in an AG‑Grid table. Records are fetched from
+ * `/api/charters` and kept in React Query cache. Client‑side filters apply the
+ * global search term and optional “My records” user filter. Clicking a short
+ * name navigates to the charter detail page. The page sets its title to
+ * “Charters” and registers an Add New option (currently a stub) through
+ * `addNewEmitter`.
+ */
 import { useQuery } from "@tanstack/react-query";
 import { AgGridReact } from "ag-grid-react";
 import type { ColDef } from "ag-grid-community";

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -1,3 +1,11 @@
+/**
+ * Application landing page. For the user selected in the header it loads action
+ * steps (`/api/action-steps/user/:id`) and schools (`/api/schools/user/:id`). It
+ * surfaces the top five incomplete tasks (overdue first) with human‑friendly due
+ * date labels and shows associated schools. An “Add New” menu registers creation
+ * modals for schools and teachers plus placeholders for charters/tasks. Each
+ * card links to the relevant detail screen.
+ */
 import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";

--- a/client/src/pages/google-sync.tsx
+++ b/client/src/pages/google-sync.tsx
@@ -1,3 +1,9 @@
+/**
+ * Lightweight wrapper that mounts the `GoogleSyncDashboard`. That dashboard
+ * handles OAuth, shows log streams, and triggers Gmail/Calendar sync edge
+ * functions. This page exists so the dashboard can live under `/google-sync` as
+ * a standalone route.
+ */
 import React from 'react';
 import { GoogleSyncDashboard } from '@/components/google/GoogleSyncDashboard';
 

--- a/client/src/pages/loan-detail.tsx
+++ b/client/src/pages/loan-detail.tsx
@@ -1,3 +1,12 @@
+/**
+ * Detail screen for a single loan. Fetches `/api/loans/:id` to obtain loan and
+ * borrower data, sets the page title to include the loan number, and formats
+ * currency/percentage/date values for display. The layout shows a summary card
+ * of principal, rate, term, etc. followed by tabs (timeline, payments,
+ * documents, related entities) which each render their own components. Status
+ * badges are color‑coded based on loan status. Loading and error states are
+ * handled before rendering content.
+ */
 import { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams, Link } from "wouter";
@@ -7,11 +16,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { 
+import {
   ArrowLeft,
-  DollarSign, 
-  Calendar, 
-  TrendingUp, 
+  DollarSign,
+  Calendar,
+  TrendingUp,
   Building2,
   MapPin,
   Users,

--- a/client/src/pages/loan-origination.tsx
+++ b/client/src/pages/loan-origination.tsx
@@ -1,3 +1,10 @@
+/**
+ * Pipeline view for loans that haven’t been fully funded. Fetches
+ * `/api/loans/origination-pipeline` and, for each loan, displays status badges
+ * and determines next steps based on flags for promissory note, ACH setup, and
+ * fund distribution. Pending loans are listed in cards with urgent actions
+ * surfaced first; when there are no pending loans a placeholder card is shown.
+ */
 import { useQuery } from "@tanstack/react-query";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";

--- a/client/src/pages/loans.tsx
+++ b/client/src/pages/loans.tsx
@@ -1,3 +1,11 @@
+/**
+ * Main hub for loan management. Contains tabs for a dashboard overview, loan
+ * list, applications, payments, documents, and settings. The dashboard tab shows
+ * summary metrics pulled from various endpoints. The loans tab can toggle
+ * between card and AG‑Grid table view. A dialog allows creating loan
+ * applications using a zod‑validated form that posts to `/api/loan-applications`.
+ * Utility components track promissory notes and quarterly reports.
+ */
 import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { usePageTitle } from "@/App";

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,3 +1,9 @@
+/**
+ * Public route for authentication. If `useAuth` reports the user is already
+ * signed in it immediately redirects to `/`. Otherwise it shows a card with a
+ * single “Continue with Google” button that calls `loginWithGoogle` which kicks
+ * off the Supabase OAuth flow restricted to `@wildflowerschools.org` domains.
+ */
 import { useEffect } from 'react';
 import { useAuth } from '@/contexts/auth-context';
 import { Button } from '@/components/ui/button';

--- a/client/src/pages/not-found.tsx
+++ b/client/src/pages/not-found.tsx
@@ -1,3 +1,8 @@
+/**
+ * Generic 404 page. Rendered when `wouter` cannot match a route. Displays an
+ * error icon, “404 Page Not Found” heading, and a reminder to register the
+ * route. No navigation controls are included.
+ */
 import { Card, CardContent } from "@/components/ui/card";
 import { AlertCircle } from "lucide-react";
 

--- a/client/src/pages/reset.tsx
+++ b/client/src/pages/reset.tsx
@@ -1,3 +1,10 @@
+/**
+ * Handles Supabase password reset links. On mount it looks for access and
+ * refresh tokens in `window.location.hash`, sets the session, and cleans the URL.
+ * Once ready, it shows a form with new password + confirmation fields. Submit
+ * validates length and equality, calls `supabase.auth.updateUser`, signs the
+ * user out, and redirects to `/login`. Errors surface via toasts.
+ */
 import React, { useEffect, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';

--- a/client/src/pages/school-detail.tsx
+++ b/client/src/pages/school-detail.tsx
@@ -1,3 +1,13 @@
+/**
+ * Comprehensive detail page for a school. Loads the school record by id and sets
+ * up forms for editing core fields using `react-hook-form` with zod validation.
+ * Multiple tabs break out related data: Summary (branding + map), Locations, and
+ * Guides, each delegating to the tab components in `components/school/tabs`.
+ * The page wires Add New options to modals for assigning existing educators or
+ * creating-and-assigning new ones. It also exposes various grids (e.g., TL
+ * associations) and uses `useTableRefresh` to keep subtable data fresh after
+ * mutations.
+ */
 import { useParams } from "wouter";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";

--- a/client/src/pages/schools.tsx
+++ b/client/src/pages/schools.tsx
@@ -1,3 +1,11 @@
+/**
+ * Index of schools. Uses `useCachedSchools` to load all non‑archived schools,
+ * filters them in memory based on the global search term and the “My records”
+ * toggle (matches current guides or assigned partner), and renders the result in
+ * `SchoolsGrid`. The page registers an Add New option opening `AddSchoolModal`,
+ * logs debug information about filtering, and tracks the grid’s internal
+ * filtered row count via callback.
+ */
 import { useState, useEffect } from "react";
 import SchoolsGrid from "@/components/schools-grid";
 import AddSchoolModal from "@/components/add-school-modal";

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -1,3 +1,10 @@
+/**
+ * User settings page. On mount sets the page title. Currently displays the
+ * signed‑in user’s email, placeholders for appearance and notification
+ * preferences, and a button that calls `supabase.auth.resetPasswordForEmail`
+ * to send a password reset link (redirecting to `/reset`). Future settings can
+ * expand within the grid layout.
+ */
 import { useEffect, useState } from "react";
 import { usePageTitle } from "@/App";
 import { Button } from "@/components/ui/button";

--- a/client/src/pages/teacher-detail.tsx
+++ b/client/src/pages/teacher-detail.tsx
@@ -1,3 +1,11 @@
+/**
+ * Detailed view for a single educator. Fetches `/api/teachers/:id` and renders
+ * tabbed content for summary info, school associations, online forms,
+ * certifications, events, notes, and linked systems via tab components under
+ * `components/teacher/tabs`. The page also manages inline editing for email
+ * addresses using a `GridTableCard` and exposes a mutation to update top-level
+ * educator fields, invalidating React Query caches after save.
+ */
 import { useParams } from "wouter";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { useEffect, useState } from "react";

--- a/client/src/pages/teachers.tsx
+++ b/client/src/pages/teachers.tsx
@@ -1,3 +1,18 @@
+/**
+ * Full Teachers index. This screen pulls all educator records from Airtable via
+ * `useCachedEducators` which wraps a React Query cache. Once loaded, records are
+ * filtered entirely on the client: first by the global search term coming from
+ * `useSearch`, then optionally by the “My records” toggle from
+ * `useUserFilter` which keeps only rows where the current user is listed as an
+ * assigned partner. The derived list feeds an `AG Grid` instance rendered by
+ * `TeachersGrid`. Rows are prefetched with `prefetchEducator` so that hovering a
+ * row loads its detail data in React Query ahead of navigation. The page also
+ * registers an “Add New” action through `addNewEmitter`; selecting this opens the
+ * `AddEducatorModal` for inline creation. A small debug header shows the active
+ * search term and how many rows remain after filtering so that QA can verify the
+ * query logic. No server calls occur for filtering; all transformations happen
+ * in-memory after the initial fetch.
+ */
 import TeachersGrid from "@/components/teachers-grid";
 import { type Teacher } from "@shared/schema";
 import { useSearch } from "@/contexts/search-context";


### PR DESCRIPTION
## Summary
- deepen top-of-file descriptions across pages, tabs, and hooks so they serve as implementation specs
- document AG Grid utilities and data caching hooks with detailed behavior
- clarify functionality for school and educator screens, modals, and pipeline views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in server/simple-storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e3d7ada88321a302dff0213f5f3e