### PR TITLE
Conditionally build server for Vercel deploys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ This document orients contributors and automation/AI agents to work safely and e
 - Requirements: Node 18+, pnpm/npm, Supabase CLI (via `npx supabase`).
 - Run dev server: `npm run dev` (Express + Vite middleware).
 - Build: `npm run build` (builds client and bundles server into `dist/`).
+- Server bundle: If you change files in `server/` or `shared/`, run `node api/build-server.mjs` (or `npm run build:vercel`) before committing so `api/_server` stays current.
 - Start prod build: `npm run start`.
 
 ## Environments & Secrets

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "build:vercel": "npx vite build && node api/build-server.mjs",
+    "build:vercel": "npx vite build && (git diff --quiet HEAD^ -- server shared && echo 'Skipping server build' || node api/build-server.mjs)",
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- Skip server bundling on Vercel builds when `server/` and `shared/` sources are unchanged by checking recent git diffs.
- Document requirement to run the server bundler locally before committing backend changes so `api/_server` stays current.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:vercel`


------
https://chatgpt.com/codex/tasks/task_e_68bb45db327c83218ad97a6c653a7db3