### PR TITLE
chore: add Vercel ignore build step

### DIFF
--- a/vercel-ignore-build-step.js
+++ b/vercel-ignore-build-step.js
@@ -1,0 +1,24 @@
+import { execSync } from 'child_process';
+
+const diff = execSync('git diff --name-only HEAD^ HEAD').toString().trim().split('\n').filter(Boolean);
+
+const paths = ['client/', 'server/', 'api/', 'shared/'];
+const files = [
+  'package.json',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'npm-shrinkwrap.json',
+  'yarn.lock'
+];
+
+const hasChanges = diff.some((file) =>
+  paths.some((p) => file.startsWith(p)) || files.includes(file)
+);
+
+if (hasChanges) {
+  console.log('Changes detected in build-relevant files. Running build.');
+  process.exit(1);
+} else {
+  console.log('No relevant changes found. Skipping build.');
+  process.exit(0);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "installCommand": "NPM_CONFIG_PRODUCTION=false npm ci",
   "buildCommand": "npm run build:vercel",
+  "ignoreCommand": "node vercel-ignore-build-step.js",
   "outputDirectory": "public",
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" },


### PR DESCRIPTION
## Summary
- add Vercel build-ignore script to detect changes in important paths
- wire script into `vercel.json` via `ignoreCommand`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Cannot find name 'timestamp', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bb45d8fc88832190d99c3b22a206be