### PR TITLE
Increase spacing between grid action buttons

### DIFF
--- a/client/src/components/associations/AssociationGrid.tsx
+++ b/client/src/components/associations/AssociationGrid.tsx
@@ -222,7 +222,7 @@ export function AssociationGrid({ mode, rows, loading, editable = false, onOpen,
           const row = p.data!;
           const rowIsEditing = isEditingRow(row.id);
           return (
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-2">
               {onOpen && (
                 <Button variant="ghost" size="sm" className="h-6 w-6 p-0 hover:bg-blue-50" title="Open" onClick={() => onOpen(row)}>
                   <ExternalLink className="h-3 w-3 text-blue-600" />

--- a/client/src/components/email-addresses-table.tsx
+++ b/client/src/components/email-addresses-table.tsx
@@ -72,7 +72,7 @@ export function EmailAddressesTable({ educatorId }: EmailAddressesTableProps) {
     if (!emailAddress) return null;
 
     return (
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-2">
         <Button
           variant="ghost"
           size="sm"

--- a/client/src/components/schools-grid.tsx
+++ b/client/src/components/schools-grid.tsx
@@ -106,7 +106,7 @@ const ActionsCellRenderer = ({ data: school }: { data: School }) => {
   };
 
   return (
-    <div className="flex space-x-1">
+    <div className="flex items-center space-x-2">
       <Link href={`/school/${school.id}`}>
         <Button variant="ghost" size="sm" className="h-7 w-7 p-0">
           <ExternalLink className="h-3 w-3" />

--- a/client/src/components/teachers-grid.tsx
+++ b/client/src/components/teachers-grid.tsx
@@ -152,7 +152,7 @@ const ActionRenderer = ({ data: teacher }: { data: Educator }) => {
 
   return (
     <>
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-2">
         <Button variant="ghost" size="sm" className="h-7 w-7 p-0" asChild>
           <Link href={`/teacher/${teacher.id}`}>
             <ExternalLink className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- prevent grid action icons from overlapping by widening their spacing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Cannot find name 'timestamp', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb43ce5fcc83219fde77aa9cfdf571