### PR TITLE
Add settings page with Google sync controls

### DIFF
--- a/client-new/src/modules/app/App.tsx
+++ b/client-new/src/modules/app/App.tsx
@@ -15,6 +15,7 @@ import { initAgGridEnterprise } from '@/lib/ag-grid';
 import { EducatorsKanbanPage } from '../educators/pages/EducatorsKanbanPage';
 import { SchoolsKanbanPage } from '../schools/pages/SchoolsKanbanPage';
 import { ChartersKanbanPage } from '../charters/pages/ChartersKanbanPage';
+import { SettingsPage } from '../settings/pages/SettingsPage';
 
 export function App() {
   return (
@@ -74,6 +75,12 @@ export function App() {
               <CharterDetailPage params={params} />
             </RequireAuth>
           )}</Route>
+
+          <Route path="/settings">
+            <RequireAuth>
+              <SettingsPage />
+            </RequireAuth>
+          </Route>
 
           <Route>Not found</Route>
         </Switch>

--- a/client-new/src/modules/app/components/Header.tsx
+++ b/client-new/src/modules/app/components/Header.tsx
@@ -10,6 +10,7 @@ export function Header() {
         <Link href="/educators">Educators</Link>
         <Link href="/schools">Schools</Link>
         <Link href="/charters">Charters</Link>
+        <Link href="/settings">Settings</Link>
       </nav>
       <div className="ml-auto text-sm">
         {user ? (

--- a/client-new/src/modules/settings/components/GoogleSyncSection.tsx
+++ b/client-new/src/modules/settings/components/GoogleSyncSection.tsx
@@ -1,0 +1,700 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { supabase } from '@/lib/supabase/client';
+
+const GMAIL_FN = 'gmail-sync';
+const CAL_FN = 'gcal-sync';
+
+const SYNC_MESSAGES_TABLE = 'google_sync_messages';
+const GMAIL_WEEKLY_TABLE = 'g_email_sync_progress';
+const CAL_MONTHLY_TABLE = 'g_event_sync_progress';
+
+type SyncStatus = 'not_started' | 'running' | 'paused' | 'completed' | 'error';
+type Service = 'gmail' | 'calendar';
+
+type GmailProgressRow = {
+  user_id: string;
+  run_id: string | null;
+  year: number;
+  week: number;
+  sync_status: SyncStatus;
+  error_message: string | null;
+  total_messages?: number | null;
+  processed_messages?: number | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  updated_at?: string | null;
+  current_run_id?: string | null;
+};
+
+type CalendarProgressRow = {
+  user_id: string;
+  run_id: string | null;
+  year: number;
+  month: number;
+  sync_status: SyncStatus;
+  error_message: string | null;
+  total_events?: number | null;
+  processed_events?: number | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  updated_at?: string | null;
+  current_run_id?: string | null;
+};
+
+type ConsoleRow = {
+  id: string;
+  service: Service;
+  message: string;
+  created_at: string;
+};
+
+export type GoogleSyncNotification = { type: 'info' | 'error'; text: string };
+
+export type GoogleSyncSummary = {
+  gmailSyncedThrough: string;
+  gmailMostRecent: string;
+  calendarSyncedThrough: string;
+  calendarMostRecent: string;
+};
+
+export interface GoogleSyncSectionProps {
+  onNotify?: (note: GoogleSyncNotification) => void;
+  onSyncSummary?: (summary: GoogleSyncSummary) => void;
+}
+
+const buttonStyle: React.CSSProperties = {
+  padding: '6px 10px',
+  borderRadius: 4,
+  border: '1px solid #cbd5f5',
+  background: '#f8fafc',
+  fontSize: 13,
+};
+
+const primaryButtonStyle: React.CSSProperties = {
+  ...buttonStyle,
+  background: '#1d4ed8',
+  border: '1px solid #1d4ed8',
+  color: '#fff',
+};
+
+function disabledStyle(base: React.CSSProperties, disabled: boolean) {
+  if (!disabled) return base;
+  return { ...base, opacity: 0.6, cursor: 'not-allowed' };
+}
+
+const badgeStyle: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '2px 6px',
+  borderRadius: 12,
+  border: '1px solid #d1d5db',
+  background: '#f3f4f6',
+  fontSize: 12,
+};
+
+const sectionCard: React.CSSProperties = {
+  border: '1px solid #d1d5db',
+  borderRadius: 6,
+  padding: 16,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+function formatIso(iso?: string | null) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return '';
+  }
+}
+
+function formatStatus(status?: SyncStatus | null) {
+  if (!status) return 'unknown';
+  return status.replace(/_/g, ' ');
+}
+
+export function GoogleSyncSection({ onNotify, onSyncSummary }: GoogleSyncSectionProps) {
+  const notify = (type: 'info' | 'error', text: string) => onNotify?.({ type, text });
+
+  const [connected, setConnected] = useState(false);
+  const [checkingConn, setCheckingConn] = useState(true);
+  const [connecting, setConnecting] = useState(false);
+  const [lastVerified, setLastVerified] = useState('');
+
+  const [gmailRow, setGmailRow] = useState<GmailProgressRow | null>(null);
+  const gmailRunId = gmailRow?.current_run_id ?? gmailRow?.run_id ?? null;
+  const [gmailSyncedThrough, setGmailSyncedThrough] = useState('');
+  const [gmailMostRecent, setGmailMostRecent] = useState('');
+
+  const [calRow, setCalRow] = useState<CalendarProgressRow | null>(null);
+  const calRunId = calRow?.current_run_id ?? calRow?.run_id ?? null;
+  const [calSyncedThrough, setCalSyncedThrough] = useState('');
+  const [calMostRecent, setCalMostRecent] = useState('');
+
+  const [consoleRows, setConsoleRows] = useState<ConsoleRow[]>([]);
+  const consoleEndRef = useRef<HTMLDivElement>(null);
+  const pollTimers = useRef<{ gmail: number | null; calendar: number | null }>({ gmail: null, calendar: null });
+  const seenIds = useRef<{ gmail: Set<string>; calendar: Set<string> }>({ gmail: new Set(), calendar: new Set() });
+
+  useEffect(() => {
+    consoleEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [consoleRows]);
+
+  const authHeaders = async () => {
+    const { data: { session } } = await supabase.auth.getSession();
+    const token = session?.access_token;
+    if (!token) throw new Error('You must be signed in to use Google sync.');
+    return { Authorization: `Bearer ${token}` };
+  };
+
+  const addConsole = (service: Service, message: string, created_at?: string) => {
+    setConsoleRows(prev => [
+      ...prev,
+      {
+        id: `${service}-${crypto.randomUUID()}`,
+        service,
+        message: `[${new Date(created_at ?? Date.now()).toLocaleTimeString()}] ${message}`,
+        created_at: created_at ?? new Date().toISOString(),
+      },
+    ]);
+  };
+
+  const pushDbConsole = (service: Service, row: { id: string; message: string; created_at: string }) => {
+    setConsoleRows(prev => {
+      if (prev.some(r => r.id === row.id)) return prev;
+      return [
+        ...prev,
+        {
+          id: row.id,
+          service,
+          message: `[${new Date(row.created_at).toLocaleTimeString()}] ${row.message}`,
+          created_at: row.created_at,
+        },
+      ];
+    });
+  };
+
+  const checkConnection = async () => {
+    try {
+      setCheckingConn(true);
+      const headers = await authHeaders();
+      const { data, error } = await supabase.functions.invoke(GMAIL_FN, { body: { action: 'get_connection_status' }, headers });
+      if (error) throw new Error(error.message || 'Unable to verify connection');
+      const ok = Boolean(data?.connected);
+      setConnected(ok);
+      setLastVerified(ok ? new Date().toLocaleString() : '');
+      if (!ok) {
+        notify('info', 'Google is not connected yet. Use “Connect Google” to authorize.');
+      }
+    } catch (e: any) {
+      setConnected(false);
+      setLastVerified('');
+      notify('error', e?.message || 'Unable to verify Google connection.');
+    } finally {
+      setCheckingConn(false);
+    }
+  };
+
+  const loadSyncedThroughBadges = async () => {
+    try {
+      const { data: u } = await supabase.auth.getUser();
+      const uid = u.user?.id;
+      if (!uid) return;
+
+      const summary: GoogleSyncSummary = {
+        gmailSyncedThrough: '',
+        gmailMostRecent: '',
+        calendarSyncedThrough: '',
+        calendarMostRecent: '',
+      };
+
+      const { data: gmailData } = await (supabase.from as any)(GMAIL_WEEKLY_TABLE)
+        .select('year, week, completed_at, updated_at')
+        .eq('user_id', uid)
+        .eq('sync_status', 'completed')
+        .order('year', { ascending: false })
+        .order('week', { ascending: false })
+        .limit(1);
+      if (gmailData?.[0]) {
+        const y = gmailData[0].year;
+        const wk = gmailData[0].week;
+        const base = new Date(Date.UTC(y, 0, 1 + (wk - 1) * 7));
+        const dow = base.getUTCDay() || 7;
+        const weekStart = new Date(base);
+        if (dow <= 4) weekStart.setUTCDate(base.getUTCDate() - base.getUTCDay() + 1);
+        else weekStart.setUTCDate(base.getUTCDate() + 8 - base.getUTCDay());
+        const weekEnd = new Date(weekStart);
+        weekEnd.setUTCDate(weekStart.getUTCDate() + 6);
+        const fmt = (d: Date) => `${d.getUTCMonth() + 1}/${d.getUTCDate()}/${d.getUTCFullYear()}`;
+        const through = fmt(weekEnd);
+        setGmailSyncedThrough(through);
+        summary.gmailSyncedThrough = through;
+        const mostRecent = gmailData[0].updated_at || gmailData[0].completed_at;
+        const mostRecentFormatted = mostRecent ? new Date(mostRecent).toLocaleString() : '';
+        setGmailMostRecent(mostRecentFormatted);
+        summary.gmailMostRecent = mostRecentFormatted;
+      } else {
+        setGmailSyncedThrough('');
+        setGmailMostRecent('');
+      }
+
+      const { data: calData } = await (supabase.from as any)(CAL_MONTHLY_TABLE)
+        .select('year, month, completed_at, updated_at')
+        .eq('user_id', uid)
+        .eq('sync_status', 'completed')
+        .order('year', { ascending: false })
+        .order('month', { ascending: false })
+        .limit(1);
+      if (calData?.[0]) {
+        const y = calData[0].year;
+        const mo = calData[0].month;
+        const monthEnd = new Date(Date.UTC(y, mo, 0));
+        const fmt = (d: Date) => `${d.getUTCMonth() + 1}/${d.getUTCDate()}/${d.getUTCFullYear()}`;
+        const through = fmt(monthEnd);
+        setCalSyncedThrough(through);
+        summary.calendarSyncedThrough = through;
+        const mostRecent = calData[0].updated_at || calData[0].completed_at;
+        const mostRecentFormatted = mostRecent ? new Date(mostRecent).toLocaleString() : '';
+        setCalMostRecent(mostRecentFormatted);
+        summary.calendarMostRecent = mostRecentFormatted;
+      } else {
+        setCalSyncedThrough('');
+        setCalMostRecent('');
+      }
+
+      onSyncSummary?.(summary);
+    } catch (e: any) {
+      notify('error', e?.message || 'Unable to load sync progress.');
+    }
+  };
+
+  const refreshGmailStatus = async () => {
+    const { data: u } = await supabase.auth.getUser();
+    const uid = u.user?.id;
+    if (!uid) return;
+    const { data: rows, error } = await (supabase.from as any)(GMAIL_WEEKLY_TABLE)
+      .select('*')
+      .eq('user_id', uid)
+      .order('started_at', { ascending: false, nullsFirst: false })
+      .order('updated_at', { ascending: false, nullsFirst: false })
+      .limit(1);
+    if (error) {
+      notify('error', error.message || 'Unable to load Gmail sync status.');
+      return;
+    }
+    setGmailRow(rows?.[0] ?? null);
+    await loadSyncedThroughBadges();
+  };
+
+  const refreshCalStatus = async () => {
+    const { data: u } = await supabase.auth.getUser();
+    const uid = u.user?.id;
+    if (!uid) return;
+    const { data: rows, error } = await (supabase.from as any)(CAL_MONTHLY_TABLE)
+      .select('*')
+      .eq('user_id', uid)
+      .order('started_at', { ascending: false, nullsFirst: false })
+      .order('updated_at', { ascending: false, nullsFirst: false })
+      .limit(1);
+    if (error) {
+      notify('error', error.message || 'Unable to load Calendar sync status.');
+      return;
+    }
+    setCalRow(rows?.[0] ?? null);
+    await loadSyncedThroughBadges();
+  };
+
+  const connectGoogle = async () => {
+    setConnecting(true);
+    try {
+      const headers = await authHeaders();
+      const redirectUri = `${window.location.origin}/settings`;
+      const { data, error } = await supabase.functions.invoke(GMAIL_FN, {
+        body: { action: 'get_auth_url', redirectUri },
+        headers,
+      });
+      if (error) throw new Error(error.message || 'Failed to request authorization URL');
+      const url = data?.auth_url;
+      if (!url) throw new Error('Authorization URL not returned. Check Supabase function configuration.');
+      window.location.href = url;
+    } catch (e: any) {
+      notify('error', e?.message || 'Unable to start Google authorization.');
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  useEffect(() => {
+    let mounted = true;
+    let gmailChan: ReturnType<typeof supabase.channel> | null = null;
+    let calChan: ReturnType<typeof supabase.channel> | null = null;
+
+    const init = async () => {
+      try {
+        const url = new URL(window.location.href);
+        const code = url.searchParams.get('code');
+        const state = url.searchParams.get('state');
+        if (code) {
+          const headers = await authHeaders();
+          const fn = state === 'gcal-sync' ? CAL_FN : GMAIL_FN;
+          await supabase.functions.invoke(fn, {
+            body: { action: 'exchange_code', code, redirectUri: `${window.location.origin}/settings` },
+            headers,
+          });
+          url.searchParams.delete('code');
+          url.searchParams.delete('state');
+          window.history.replaceState({}, document.title, url.pathname + (url.search ? `?${url.searchParams.toString()}` : ''));
+          notify('info', 'Google account connected.');
+          setConnected(true);
+        }
+      } catch (e: any) {
+        notify('error', e?.message || 'Failed to complete Google authorization.');
+      }
+      await checkConnection();
+      await refreshGmailStatus();
+      await refreshCalStatus();
+    };
+
+    const setupSubscriptions = async () => {
+      const { data: u } = await supabase.auth.getUser();
+      const uid = u.user?.id;
+      if (!uid) return;
+      gmailChan = supabase
+        .channel(`gmail-weekly-${uid}`)
+        .on('postgres_changes', { event: '*', schema: 'public', table: GMAIL_WEEKLY_TABLE, filter: `user_id=eq.${uid}` }, () => {
+          if (mounted) refreshGmailStatus();
+        })
+        .subscribe();
+      calChan = supabase
+        .channel(`cal-monthly-${uid}`)
+        .on('postgres_changes', { event: '*', schema: 'public', table: CAL_MONTHLY_TABLE, filter: `user_id=eq.${uid}` }, () => {
+          if (mounted) refreshCalStatus();
+        })
+        .subscribe();
+    };
+
+    init();
+    setupSubscriptions();
+
+    return () => {
+      mounted = false;
+      if (gmailChan) supabase.removeChannel(gmailChan);
+      if (calChan) supabase.removeChannel(calChan);
+      if (pollTimers.current.gmail) window.clearTimeout(pollTimers.current.gmail);
+      if (pollTimers.current.calendar) window.clearTimeout(pollTimers.current.calendar);
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!gmailRunId) return;
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    (async () => {
+      const { data: u } = await supabase.auth.getUser();
+      const uid = u.user?.id;
+      if (!uid) return;
+      channel = supabase
+        .channel(`sync-messages-gmail-${uid}-${gmailRunId}`)
+        .on('postgres_changes', { event: 'INSERT', schema: 'public', table: SYNC_MESSAGES_TABLE, filter: `user_id=eq.${uid},run_id=eq.${gmailRunId},sync_type=eq.gmail` }, (payload) => {
+          const row: any = payload.new;
+          if (!row?.id || !row?.message || !row?.created_at) return;
+          if (seenIds.current.gmail.has(row.id)) return;
+          seenIds.current.gmail.add(row.id);
+          pushDbConsole('gmail', row);
+        })
+        .subscribe();
+
+      const poll = async () => {
+        const { data: u2 } = await supabase.auth.getUser();
+        const uid2 = u2.user?.id;
+        if (!uid2) return;
+        const { data: rows } = await (supabase.from as any)(SYNC_MESSAGES_TABLE)
+          .select('id, message, created_at')
+          .eq('user_id', uid2)
+          .eq('sync_type', 'gmail')
+          .order('created_at', { ascending: true })
+          .limit(1000);
+        if (rows?.length) {
+          for (const r of rows) {
+            if (seenIds.current.gmail.has(r.id)) continue;
+            seenIds.current.gmail.add(r.id);
+            pushDbConsole('gmail', r);
+          }
+        }
+        pollTimers.current.gmail = window.setTimeout(poll, 10000);
+      };
+      pollTimers.current.gmail = window.setTimeout(poll, 1000);
+    })();
+
+    return () => {
+      if (channel) supabase.removeChannel(channel);
+      if (pollTimers.current.gmail) {
+        window.clearTimeout(pollTimers.current.gmail);
+        pollTimers.current.gmail = null;
+      }
+    };
+  }, [gmailRunId]);
+
+  useEffect(() => {
+    if (!calRunId) return;
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    (async () => {
+      const { data: u } = await supabase.auth.getUser();
+      const uid = u.user?.id;
+      if (!uid) return;
+      channel = supabase
+        .channel(`sync-messages-cal-${uid}-${calRunId}`)
+        .on('postgres_changes', { event: 'INSERT', schema: 'public', table: SYNC_MESSAGES_TABLE, filter: `user_id=eq.${uid},run_id=eq.${calRunId},sync_type=eq.calendar` }, (payload) => {
+          const row: any = payload.new;
+          if (!row?.id || !row?.message || !row?.created_at) return;
+          if (seenIds.current.calendar.has(row.id)) return;
+          seenIds.current.calendar.add(row.id);
+          pushDbConsole('calendar', row);
+        })
+        .subscribe();
+
+      const poll = async () => {
+        const { data: u2 } = await supabase.auth.getUser();
+        const uid2 = u2.user?.id;
+        if (!uid2) return;
+        const { data: rows } = await (supabase.from as any)(SYNC_MESSAGES_TABLE)
+          .select('id, message, created_at')
+          .eq('user_id', uid2)
+          .eq('sync_type', 'calendar')
+          .order('created_at', { ascending: true })
+          .limit(1000);
+        if (rows?.length) {
+          for (const r of rows) {
+            if (seenIds.current.calendar.has(r.id)) continue;
+            seenIds.current.calendar.add(r.id);
+            pushDbConsole('calendar', r);
+          }
+        }
+        pollTimers.current.calendar = window.setTimeout(poll, 10000);
+      };
+      pollTimers.current.calendar = window.setTimeout(poll, 1000);
+    })();
+
+    return () => {
+      if (channel) supabase.removeChannel(channel);
+      if (pollTimers.current.calendar) {
+        window.clearTimeout(pollTimers.current.calendar);
+        pollTimers.current.calendar = null;
+      }
+    };
+  }, [calRunId]);
+
+  const actionButton = (opts: { label: string; onClick: () => void | Promise<void>; service: Service; disabled?: boolean }) => (
+    <button
+      type="button"
+      style={disabledStyle(buttonStyle, Boolean(opts.disabled))}
+      onClick={async () => {
+        try {
+          await opts.onClick();
+        } catch (e: any) {
+          addConsole(opts.service, `${opts.label} failed: ${e?.message || String(e)}`);
+        }
+      }}
+      disabled={opts.disabled}
+    >
+      {opts.label}
+    </button>
+  );
+
+  const gmailStatus = useMemo(() => {
+    if (!gmailRow) return 'No runs yet';
+    const parts = [
+      `Status: ${formatStatus(gmailRow.sync_status)}`,
+      gmailRow.updated_at ? `Updated: ${formatIso(gmailRow.updated_at)}` : null,
+      gmailRow.processed_messages != null && gmailRow.total_messages != null
+        ? `Processed ${gmailRow.processed_messages}/${gmailRow.total_messages}`
+        : null,
+      gmailRow.error_message ? `Error: ${gmailRow.error_message}` : null,
+    ].filter(Boolean);
+    return parts.join(' • ');
+  }, [gmailRow]);
+
+  const calendarStatus = useMemo(() => {
+    if (!calRow) return 'No runs yet';
+    const parts = [
+      `Status: ${formatStatus(calRow.sync_status)}`,
+      calRow.updated_at ? `Updated: ${formatIso(calRow.updated_at)}` : null,
+      calRow.processed_events != null && calRow.total_events != null
+        ? `Processed ${calRow.processed_events}/${calRow.total_events}`
+        : null,
+      calRow.error_message ? `Error: ${calRow.error_message}` : null,
+    ].filter(Boolean);
+    return parts.join(' • ');
+  }, [calRow]);
+
+  return (
+    <section style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ ...sectionCard, flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          <strong>Google Connection</strong>
+          <span style={{ fontSize: 13, color: '#374151' }}>
+            {checkingConn
+              ? 'Checking connection...'
+              : connected
+                ? `Connected${lastVerified ? ` (verified ${lastVerified})` : ''}`
+                : 'Not connected'}
+          </span>
+        </div>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          <button
+            type="button"
+            style={disabledStyle(buttonStyle, checkingConn)}
+            onClick={checkConnection}
+            disabled={checkingConn}
+          >
+            {checkingConn ? 'Checking...' : 'Recheck'}
+          </button>
+          <button
+            type="button"
+            style={disabledStyle(primaryButtonStyle, connecting)}
+            onClick={connectGoogle}
+            disabled={connecting}
+          >
+            {connecting ? 'Opening...' : 'Connect Google'}
+          </button>
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gap: 16,
+          gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+        }}
+      >
+        <div style={sectionCard}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <strong>Gmail</strong>
+            {gmailSyncedThrough && (
+              <span style={badgeStyle}>Synced through {gmailSyncedThrough}</span>
+            )}
+          </div>
+          <span style={{ fontSize: 13, color: '#374151' }}>{gmailStatus}</span>
+          {gmailMostRecent && (
+            <span style={{ fontSize: 12, color: '#4b5563' }}>Most recent sync: {gmailMostRecent}</span>
+          )}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {actionButton({
+              label: 'Run Week',
+              service: 'gmail',
+              onClick: async () => {
+                const headers = await authHeaders();
+                await supabase.functions.invoke(GMAIL_FN, { body: { action: 'start_sync' }, headers });
+                addConsole('gmail', 'Weekly sync started');
+              },
+            })}
+            {actionButton({
+              label: 'Backfill Bodies + Attachments',
+              service: 'gmail',
+              onClick: async () => {
+                const headers = await authHeaders();
+                await supabase.functions.invoke(GMAIL_FN, { body: { action: 'backfill_matched' }, headers });
+                addConsole('gmail', 'Backfill started for matched emails');
+              },
+            })}
+            {actionButton({
+              label: 'Refresh Matches',
+              service: 'gmail',
+              onClick: async () => {
+                const { data: u } = await supabase.auth.getUser();
+                const uid = u.user?.id;
+                if (!uid) throw new Error('Missing user id');
+                await (supabase.rpc as any)('refresh_g_emails_matches', { p_user_id: uid, p_since: null, p_merge: false });
+                addConsole('gmail', 'Refresh matches triggered');
+              },
+            })}
+          </div>
+          <div
+            style={{
+              maxHeight: 200,
+              overflowY: 'auto',
+              background: '#f9fafb',
+              border: '1px solid #e5e7eb',
+              borderRadius: 4,
+              padding: 8,
+              fontFamily: 'monospace',
+              fontSize: 12,
+            }}
+          >
+            {consoleRows
+              .filter((r) => r.service === 'gmail')
+              .map((r) => (
+                <div key={r.id}>{r.message}</div>
+              ))}
+            <div ref={consoleEndRef} />
+          </div>
+        </div>
+
+        <div style={sectionCard}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <strong>Calendar</strong>
+            {calSyncedThrough && (
+              <span style={badgeStyle}>Synced through {calSyncedThrough}</span>
+            )}
+          </div>
+          <span style={{ fontSize: 13, color: '#374151' }}>{calendarStatus}</span>
+          {calMostRecent && (
+            <span style={{ fontSize: 12, color: '#4b5563' }}>Most recent sync: {calMostRecent}</span>
+          )}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+            {actionButton({
+              label: 'Run Month',
+              service: 'calendar',
+              onClick: async () => {
+                const headers = await authHeaders();
+                await supabase.functions.invoke(CAL_FN, { body: { action: 'start_sync' }, headers });
+                addConsole('calendar', 'Monthly sync started');
+              },
+            })}
+            {actionButton({
+              label: 'Backfill Attachments',
+              service: 'calendar',
+              onClick: async () => {
+                const headers = await authHeaders();
+                await supabase.functions.invoke(CAL_FN, { body: { action: 'backfill_event_attachments' }, headers });
+                addConsole('calendar', 'Backfill attachments started');
+              },
+            })}
+            {actionButton({
+              label: 'Refresh Matches',
+              service: 'calendar',
+              onClick: async () => {
+                const { data: u } = await supabase.auth.getUser();
+                const uid = u.user?.id;
+                if (!uid) throw new Error('Missing user id');
+                await (supabase.rpc as any)('refresh_g_events_matches', { p_user_id: uid, p_since: null, p_merge: false });
+                addConsole('calendar', 'Refresh matches triggered');
+              },
+            })}
+          </div>
+          <div
+            style={{
+              maxHeight: 200,
+              overflowY: 'auto',
+              background: '#f9fafb',
+              border: '1px solid #e5e7eb',
+              borderRadius: 4,
+              padding: 8,
+              fontFamily: 'monospace',
+              fontSize: 12,
+            }}
+          >
+            {consoleRows
+              .filter((r) => r.service === 'calendar')
+              .map((r) => (
+                <div key={r.id}>{r.message}</div>
+              ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default GoogleSyncSection;

--- a/client-new/src/modules/settings/pages/SettingsPage.tsx
+++ b/client-new/src/modules/settings/pages/SettingsPage.tsx
@@ -1,0 +1,248 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabase/client';
+import { useAuth } from '../../auth/auth-context';
+import { GoogleSyncSection, type GoogleSyncNotification, type GoogleSyncSummary } from '../components/GoogleSyncSection';
+
+type EducatorProfile = {
+  full_name: string | null;
+  current_role: string | null;
+  current_role_at_active_school: string | null;
+  primary_email: string | null;
+};
+
+const containerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+  maxWidth: 960,
+  margin: '0 auto',
+};
+
+const sectionStyle: React.CSSProperties = {
+  border: '1px solid #d1d5db',
+  borderRadius: 6,
+  padding: 20,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 13,
+  color: '#4b5563',
+};
+
+const valueStyle: React.CSSProperties = {
+  fontSize: 15,
+  fontWeight: 500,
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: '6px 10px',
+  borderRadius: 4,
+  border: '1px solid #cbd5f5',
+  background: '#f8fafc',
+  fontSize: 13,
+};
+
+function disabledStyle(base: React.CSSProperties, disabled: boolean) {
+  if (!disabled) return base;
+  return { ...base, opacity: 0.6, cursor: 'not-allowed' };
+}
+
+function todayInputValue() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export function SettingsPage() {
+  const { user } = useAuth();
+  const [syncStart, setSyncStart] = useState('');
+  const [savingSync, setSavingSync] = useState(false);
+  const [banner, setBanner] = useState<GoogleSyncNotification | null>(null);
+  const [syncSummary, setSyncSummary] = useState<GoogleSyncSummary>({
+    gmailSyncedThrough: '',
+    gmailMostRecent: '',
+    calendarSyncedThrough: '',
+    calendarMostRecent: '',
+  });
+
+  const showBanner = useCallback((note: GoogleSyncNotification) => {
+    setBanner(note);
+  }, []);
+
+  const profileQuery = useQuery<EducatorProfile | null>({
+    queryKey: ['settings-profile', user?.email],
+    enabled: Boolean(user?.email),
+    queryFn: async () => {
+      if (!user?.email) return null;
+      const { data, error } = await supabase
+        .from('details_educators')
+        .select('full_name,current_role,current_role_at_active_school,primary_email')
+        .eq('primary_email', user.email)
+        .maybeSingle();
+      if (error) throw error;
+      return data as EducatorProfile | null;
+    },
+  });
+
+  useEffect(() => {
+    if (!user?.id) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data } = await (supabase.from as any)('google_sync_settings')
+          .select('sync_start_date')
+          .eq('user_id', user.id)
+          .maybeSingle();
+        if (cancelled) return;
+        const iso: string | null = data?.sync_start_date ?? null;
+        setSyncStart(iso ? iso.slice(0, 10) : todayInputValue());
+      } catch {
+        if (!cancelled) setSyncStart(todayInputValue());
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id]);
+
+  const saveSyncStart = async () => {
+    if (!user?.id || !syncStart) return;
+    try {
+      setSavingSync(true);
+      const iso = new Date(`${syncStart}T00:00:00Z`).toISOString();
+      const { data: current } = await (supabase.from as any)('google_sync_settings')
+        .select('sync_start_date')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      const previousIso: string | null = current?.sync_start_date ?? null;
+      const movedEarlier = !previousIso || new Date(iso) < new Date(previousIso);
+      const { error } = await (supabase.from as any)('google_sync_settings')
+        .upsert({ user_id: user.id, sync_start_date: iso });
+      if (error) throw error;
+      showBanner({ type: 'info', text: 'Sync start date saved.' });
+      if (movedEarlier) {
+        try {
+          await (supabase.from as any)('sync_catchup_requests').upsert({ user_id: user.id, status: 'queued' });
+          showBanner({ type: 'info', text: 'Catch-up queued. Historical ingest will run automatically.' });
+        } catch (err: any) {
+          showBanner({ type: 'error', text: err?.message || 'Failed to queue catch-up request.' });
+        }
+      }
+    } catch (e: any) {
+      showBanner({ type: 'error', text: e?.message || 'Unable to save sync start date.' });
+    } finally {
+      setSavingSync(false);
+    }
+  };
+
+  const accountDetails = useMemo(() => {
+    const profile = profileQuery.data;
+    const name = profile?.full_name || profile?.primary_email || user?.email || '—';
+    const role = profile?.current_role_at_active_school || profile?.current_role || '—';
+    return { name, role };
+  }, [profileQuery.data, user?.email]);
+
+  const syncSummaryList = [
+    { label: 'Gmail synced through', value: syncSummary.gmailSyncedThrough || '—' },
+    { label: 'Gmail most recent sync', value: syncSummary.gmailMostRecent || '—' },
+    { label: 'Calendar synced through', value: syncSummary.calendarSyncedThrough || '—' },
+    { label: 'Calendar most recent sync', value: syncSummary.calendarMostRecent || '—' },
+  ];
+
+  return (
+    <main style={{ padding: 24 }}>
+      <div style={containerStyle}>
+        <header>
+          <h1 style={{ margin: 0 }}>Settings</h1>
+          <p style={{ margin: '8px 0 0', color: '#4b5563', fontSize: 14 }}>
+            Review your account details and manage Google sync preferences.
+          </p>
+        </header>
+
+        {banner && (
+          <div
+            style={{
+              padding: '8px 12px',
+              borderRadius: 6,
+              border: '1px solid',
+              borderColor: banner.type === 'error' ? '#f87171' : '#93c5fd',
+              background: banner.type === 'error' ? '#fee2e2' : '#eff6ff',
+              color: banner.type === 'error' ? '#b91c1c' : '#1d4ed8',
+              fontSize: 14,
+            }}
+          >
+            {banner.text}
+          </div>
+        )}
+
+        <section style={sectionStyle}>
+          <h2 style={{ margin: 0 }}>Account</h2>
+          <div style={{ display: 'grid', gap: 12, gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))' }}>
+            <div>
+              <div style={labelStyle}>Name</div>
+              <div style={valueStyle}>{profileQuery.isLoading ? 'Loading…' : accountDetails.name}</div>
+            </div>
+            <div>
+              <div style={labelStyle}>Email</div>
+              <div style={valueStyle}>{user?.email || '—'}</div>
+            </div>
+            <div>
+              <div style={labelStyle}>Role</div>
+              <div style={valueStyle}>{profileQuery.isLoading ? 'Loading…' : accountDetails.role}</div>
+            </div>
+          </div>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2 style={{ margin: 0 }}>Google Sync Range</h2>
+          <p style={{ margin: 0, fontSize: 13, color: '#4b5563' }}>
+            Set the earliest date to include when syncing Gmail and Calendar.
+          </p>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}>
+            <input
+              type="date"
+              value={syncStart}
+              onChange={(e) => setSyncStart(e.target.value)}
+              style={{ padding: '6px 8px', borderRadius: 4, border: '1px solid #d1d5db' }}
+            />
+            <button
+              type="button"
+              style={disabledStyle(buttonStyle, savingSync)}
+              onClick={saveSyncStart}
+              disabled={savingSync}
+            >
+              {savingSync ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2 style={{ margin: 0 }}>Sync Status</h2>
+          <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}>
+            {syncSummaryList.map((item) => (
+              <div key={item.label}>
+                <div style={labelStyle}>{item.label}</div>
+                <div style={valueStyle}>{item.value}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section style={sectionStyle}>
+          <h2 style={{ margin: 0 }}>Google Sync Controls</h2>
+          <p style={{ margin: 0, fontSize: 13, color: '#4b5563' }}>
+            Authorize Google, monitor sync runs, and trigger Gmail or Calendar updates.
+          </p>
+          <GoogleSyncSection
+            onNotify={showBanner}
+            onSyncSummary={(summary) => setSyncSummary(summary)}
+          />
+        </section>
+      </div>
+    </main>
+  );
+}
+
+export default SettingsPage;


### PR DESCRIPTION
## Summary
- add a settings page that surfaces account details, sync range, status, and embeds the Google sync controls from the legacy app
- port the Google sync dashboard logic into the new client with lightweight styling and notifications
- register the new route and expose a Settings link in the header navigation

## Testing
- `npm run typecheck --prefix client-new` *(fails: existing missing symbol errors in src/modules/charters/constants.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68caa7a628a883219182921d60b6c05c