### PR TITLE
Add Airtable to Supabase sync utility

### DIFF
--- a/client-new/package-lock.json
+++ b/client-new/package-lock.json
@@ -8,11 +8,14 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.57.4",
         "@tanstack/react-query": "^5.60.5",
+        "@types/node": "^24.5.1",
         "ag-grid-community": "^34.1.2",
         "ag-grid-enterprise": "^34.1.2",
         "ag-grid-react": "^34.1.2",
+        "airtable": "^0.12.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "tsx": "^4.20.5",
         "wouter": "^3.3.5"
       },
       "devDependencies": {
@@ -594,6 +597,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -611,6 +630,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -626,6 +661,22 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -1200,12 +1251,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.4.0.tgz",
-      "integrity": "sha512-gUuVEAK4/u6F9wRLznPUU4WGUacSEBDPoC2TrBkw3GAnOLHBL45QdfHOXp1kJ4ypBGLxTOB+t7NJLpKoC3gznQ==",
+      "version": "24.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.1.tgz",
+      "integrity": "sha512-/SQdmUP2xa+1rdx7VwB9yPq8PaKej8TD5cQ+XfKDPWWC+VDJU4rvVVagXqKUzhKjtFoNA8rXDJAkCxQPAe00+Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.11.0"
+        "undici-types": "~7.12.0"
       }
     },
     "node_modules/@types/phoenix": {
@@ -1271,6 +1322,24 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
+      "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
+      "license": "MIT"
     },
     "node_modules/ag-charts-community": {
       "version": "12.2.0",
@@ -1353,6 +1422,28 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/airtable": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/airtable/-/airtable-0.12.2.tgz",
+      "integrity": "sha512-HS3VytUBTKj8A0vPl7DDr5p/w3IOGv6RXL0fv7eczOWAtj9Xe8ri4TAiZRXoOyo+Z/COADCj+oARFenbxhmkIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.0.0 <15",
+        "abort-controller": "^3.0.0",
+        "abortcontroller-polyfill": "^1.4.0",
+        "lodash": "^4.17.21",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/airtable/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.3",
@@ -1507,11 +1598,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1530,6 +1629,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/js-tokens": {
@@ -1563,6 +1674,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -1616,6 +1733,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -1731,6 +1868,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.50.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz",
@@ -1807,6 +1953,434 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.9",
+        "@esbuild/android-arm": "0.25.9",
+        "@esbuild/android-arm64": "0.25.9",
+        "@esbuild/android-x64": "0.25.9",
+        "@esbuild/darwin-arm64": "0.25.9",
+        "@esbuild/darwin-x64": "0.25.9",
+        "@esbuild/freebsd-arm64": "0.25.9",
+        "@esbuild/freebsd-x64": "0.25.9",
+        "@esbuild/linux-arm": "0.25.9",
+        "@esbuild/linux-arm64": "0.25.9",
+        "@esbuild/linux-ia32": "0.25.9",
+        "@esbuild/linux-loong64": "0.25.9",
+        "@esbuild/linux-mips64el": "0.25.9",
+        "@esbuild/linux-ppc64": "0.25.9",
+        "@esbuild/linux-riscv64": "0.25.9",
+        "@esbuild/linux-s390x": "0.25.9",
+        "@esbuild/linux-x64": "0.25.9",
+        "@esbuild/netbsd-arm64": "0.25.9",
+        "@esbuild/netbsd-x64": "0.25.9",
+        "@esbuild/openbsd-arm64": "0.25.9",
+        "@esbuild/openbsd-x64": "0.25.9",
+        "@esbuild/openharmony-arm64": "0.25.9",
+        "@esbuild/sunos-x64": "0.25.9",
+        "@esbuild/win32-arm64": "0.25.9",
+        "@esbuild/win32-ia32": "0.25.9",
+        "@esbuild/win32-x64": "0.25.9"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -1822,9 +2396,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.11.0.tgz",
-      "integrity": "sha512-kt1ZriHTi7MU+Z/r9DOdAI3ONdaR3M3csEaRc6ewa4f4dTvX4cQCbJ4NkEn0ohE4hHtq85+PhPSTY+pO/1PwgA==",
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
+      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/client-new/package.json
+++ b/client-new/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "airtable:sync": "tsx scripts/airtable-to-supabase.ts",
+    "airtable:sync:dry": "tsx scripts/airtable-to-supabase.ts --dry-run"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",
@@ -14,16 +16,18 @@
     "ag-grid-community": "^34.1.2",
     "ag-grid-enterprise": "^34.1.2",
     "ag-grid-react": "^34.1.2",
+    "airtable": "^0.12.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "wouter": "^3.3.5"
   },
   "devDependencies": {
+    "@types/node": "^24.5.1",
     "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
     "@vitejs/plugin-react": "^4.3.2",
+    "tsx": "^4.20.5",
     "typescript": "5.6.3",
     "vite": "^5.4.19"
   }
 }
-

--- a/client-new/scripts/README.md
+++ b/client-new/scripts/README.md
@@ -1,0 +1,36 @@
+# Airtable → Supabase Sync Scripts
+
+This directory contains the `airtable-to-supabase.ts` utility that performs a one-way sync from Airtable into Supabase.
+
+## Setup
+
+1. Copy `airtable-sync.config.example.json` to `airtable-sync.config.json` and edit it so that each entry describes how an Airtable table maps to its Supabase counterpart.
+2. Create (or update) `scripts/airtable-sync-state.json` if you want to seed an initial `lastSyncedAt` timestamp. The file will be created automatically after the first successful run.
+3. Set the required environment variables before running the script:
+   - `AIRTABLE_API_KEY`
+   - `AIRTABLE_BASE_ID` (or set `baseId` in the config file)
+   - `SUPABASE_URL`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+
+## Running the script
+
+Run the sync (inserts new Airtable records into Supabase, prints diffs for modified rows):
+
+```bash
+npm run airtable:sync
+```
+
+Preview the changes without writing to Supabase or updating the sync state:
+
+```bash
+npm run airtable:sync:dry
+```
+
+## How it works
+
+- The script fetches Airtable records that changed since the last `lastSyncedAt` timestamp stored in `airtable-sync-state.json` (per Supabase table).
+- New Airtable records that do not have a matching Supabase row (based on the configured primary key) are inserted.
+- Existing records with differing field values are reported with field-level diffs so you can review them before overwriting Supabase manually.
+- After a successful non-dry run, the script updates `airtable-sync-state.json` with the current timestamp.
+
+> **Note:** To capture human-friendly “last modified” timestamps in the diff report, add a formula field in Airtable (e.g. `DATETIME_FORMAT(LAST_MODIFIED_TIME(), 'YYYY-MM-DDTHH:mm:ssZ')`) and reference it via `lastModifiedField` in the config.

--- a/client-new/scripts/airtable-sync.config.example.json
+++ b/client-new/scripts/airtable-sync.config.example.json
@@ -1,0 +1,16 @@
+{
+  "baseId": "appXXXXXXXXXXXXXXXX",
+  "tables": [
+    {
+      "name": "Example Table",
+      "airtableTable": "Teachers",
+      "view": "Grid view",
+      "lastModifiedField": "Last Modified",
+      "supabaseTable": "teachers",
+      "primaryKey": "id",
+      "airtableIdField": "airtable_id",
+      "useAirtableRecordId": true,
+      "fields": ["Name", "Email", "Status", "Last Modified"]
+    }
+  ]
+}

--- a/client-new/scripts/airtable-to-supabase.ts
+++ b/client-new/scripts/airtable-to-supabase.ts
@@ -1,0 +1,342 @@
+import Airtable from 'airtable';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+interface TableConfig {
+  /** Human friendly name shown in logs */
+  name?: string;
+  /** Airtable table name */
+  airtableTable: string;
+  /** Optional Airtable view to scope queries */
+  view?: string;
+  /** Optional Airtable field (formula) containing the last modified time string */
+  lastModifiedField?: string;
+  /** Supabase table name */
+  supabaseTable: string;
+  /** Column in Supabase used to match rows */
+  primaryKey: string;
+  /** Optional column in Supabase to store the Airtable record id */
+  airtableIdField?: string;
+  /** If true use the Airtable record id as the Supabase primary key value */
+  useAirtableRecordId?: boolean;
+  /** Explicit field allow-list. If omitted all Airtable fields are copied */
+  fields?: string[];
+}
+
+interface SyncConfig {
+  /** Airtable base id. Falls back to AIRTABLE_BASE_ID env var */
+  baseId?: string;
+  /** Per-table sync configuration */
+  tables: TableConfig[];
+}
+
+interface SyncState {
+  [tableName: string]: {
+    lastSyncedAt: string;
+  };
+}
+
+interface ParsedArgs {
+  configPath: string;
+  statePath: string;
+  dryRun: boolean;
+}
+
+interface FieldDifference {
+  field: string;
+  airtableValue: unknown;
+  supabaseValue: unknown;
+}
+
+interface DiffReport {
+  primaryKeyValue: string;
+  lastModifiedTime: string | null;
+  differences: FieldDifference[];
+}
+
+const DEFAULT_CONFIG_PATH = path.resolve(process.cwd(), 'scripts/airtable-sync.config.json');
+const DEFAULT_STATE_PATH = path.resolve(process.cwd(), 'scripts/airtable-sync-state.json');
+
+function parseArgs(): ParsedArgs {
+  const args = process.argv.slice(2);
+  const parsed: ParsedArgs = {
+    configPath: DEFAULT_CONFIG_PATH,
+    statePath: DEFAULT_STATE_PATH,
+    dryRun: false,
+  };
+
+  for (const arg of args) {
+    if (!arg.startsWith('--')) continue;
+    const [flag, rawValue] = arg.slice(2).split('=');
+    const value = rawValue ?? 'true';
+    switch (flag) {
+      case 'config':
+        parsed.configPath = path.resolve(process.cwd(), value);
+        break;
+      case 'state':
+        parsed.statePath = path.resolve(process.cwd(), value);
+        break;
+      case 'dry-run':
+      case 'dryRun':
+        parsed.dryRun = value === 'true';
+        break;
+      default:
+        console.warn(`Unknown flag: --${flag}`);
+    }
+  }
+
+  return parsed;
+}
+
+async function loadConfig(configPath: string): Promise<SyncConfig> {
+  try {
+    const raw = await fs.readFile(configPath, 'utf8');
+    const config = JSON.parse(raw) as SyncConfig;
+    if (!config.tables?.length) {
+      throw new Error('Config must include at least one table definition.');
+    }
+    return config;
+  } catch (error) {
+    throw new Error(`Unable to read config at ${configPath}: ${(error as Error).message}`);
+  }
+}
+
+async function loadState(statePath: string): Promise<SyncState> {
+  try {
+    const raw = await fs.readFile(statePath, 'utf8');
+    return JSON.parse(raw) as SyncState;
+  } catch (error) {
+    return {};
+  }
+}
+
+async function saveState(statePath: string, state: SyncState) {
+  await fs.mkdir(path.dirname(statePath), { recursive: true });
+  const payload = JSON.stringify(state, null, 2);
+  await fs.writeFile(statePath, `${payload}\n`, 'utf8');
+}
+
+function assertEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined) return '' + value;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return JSON.stringify(value);
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+    return `{${entries.map(([key, val]) => `${key}:${stableStringify(val)}`).join(',')}}`;
+  }
+  return String(value);
+}
+
+function buildRow(record: Airtable.Record<any>, table: TableConfig) {
+  const rawFields = record.fields as Record<string, unknown>;
+  const fieldNames = table.fields ?? Object.keys(rawFields);
+  const row: Record<string, unknown> = {};
+
+  for (const fieldName of fieldNames) {
+    if (Object.prototype.hasOwnProperty.call(rawFields, fieldName)) {
+      row[fieldName] = rawFields[fieldName];
+    } else {
+      row[fieldName] = null;
+    }
+  }
+
+  if (table.airtableIdField) {
+    row[table.airtableIdField] = record.id;
+  }
+
+  if (table.useAirtableRecordId) {
+    row[table.primaryKey] = record.id;
+  } else if (!Object.prototype.hasOwnProperty.call(row, table.primaryKey)) {
+    const pkValue = rawFields[table.primaryKey];
+    if (pkValue !== undefined) {
+      row[table.primaryKey] = pkValue;
+    }
+  }
+
+  return row;
+}
+
+function getPrimaryKeyValue(record: Airtable.Record<any>, table: TableConfig) {
+  if (table.useAirtableRecordId) {
+    return record.id;
+  }
+  const rawFields = record.fields as Record<string, unknown>;
+  const value = rawFields[table.primaryKey];
+  if (value === undefined) {
+    throw new Error(
+      `Record ${record.id} from ${table.airtableTable} is missing primary key field ${table.primaryKey}`,
+    );
+  }
+  return value as string | number;
+}
+
+function groupDifferences(reports: DiffReport[]): string {
+  if (!reports.length) return '  No differences found.';
+  const lines: string[] = [];
+  for (const report of reports) {
+    const header = `  • ${report.primaryKeyValue}${report.lastModifiedTime ? ` (last modified ${report.lastModifiedTime})` : ''}`;
+    lines.push(header);
+    for (const diff of report.differences) {
+      const airtableValue = stableStringify(diff.airtableValue);
+      const supabaseValue = stableStringify(diff.supabaseValue);
+      lines.push(`      - ${diff.field}: Airtable=${airtableValue} | Supabase=${supabaseValue}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+async function run() {
+  const args = parseArgs();
+  const config = await loadConfig(args.configPath);
+  const state = await loadState(args.statePath);
+
+  const airtableApiKey = assertEnv('AIRTABLE_API_KEY');
+  const airtableBaseId = config.baseId ?? assertEnv('AIRTABLE_BASE_ID');
+  const supabaseUrl = assertEnv('SUPABASE_URL');
+  const supabaseKey = assertEnv('SUPABASE_SERVICE_ROLE_KEY');
+
+  const airtableBase = new Airtable({ apiKey: airtableApiKey }).base(airtableBaseId);
+  const supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
+
+  const newState: SyncState = { ...state };
+  const summaryLines: string[] = [];
+
+  for (const table of config.tables) {
+    const label = table.name ?? table.supabaseTable;
+    console.log(`\n=== Syncing ${label} ===`);
+
+    const lastSyncedAt = state[table.supabaseTable]?.lastSyncedAt;
+    const filterFormula = lastSyncedAt ? `IS_AFTER(LAST_MODIFIED_TIME(), '${lastSyncedAt}')` : undefined;
+
+    const airtableRecords = await airtableBase(table.airtableTable)
+      .select({
+        view: table.view,
+        filterByFormula: filterFormula,
+      })
+      .all();
+
+    if (!airtableRecords.length) {
+      console.log('  No Airtable changes detected.');
+      newState[table.supabaseTable] = { lastSyncedAt: new Date().toISOString() };
+      summaryLines.push(`${label}: inserted 0 new record(s); 0 record(s) with differences.`);
+      continue;
+    }
+
+    const primaryKeyValues = airtableRecords.map((record) => getPrimaryKeyValue(record, table));
+
+    const { data: existingRows, error: existingError } = await supabase
+      .from(table.supabaseTable)
+      .select()
+      .in(table.primaryKey, primaryKeyValues);
+
+    if (existingError) {
+      throw new Error(`Supabase select failed for table ${table.supabaseTable}: ${existingError.message}`);
+    }
+
+    const supabaseByPk = new Map<string | number, Record<string, unknown>>();
+    for (const row of existingRows ?? []) {
+      const key = row[table.primaryKey] as string | number;
+      supabaseByPk.set(key, row);
+    }
+
+    const rowsToInsert: Record<string, unknown>[] = [];
+    const diffReports: DiffReport[] = [];
+
+    for (const record of airtableRecords) {
+      const pkValue = getPrimaryKeyValue(record, table);
+      const supabaseRow = supabaseByPk.get(pkValue);
+      if (!supabaseRow) {
+        rowsToInsert.push(buildRow(record, table));
+        continue;
+      }
+
+      const fieldsToCompare = table.fields ?? Object.keys(record.fields as Record<string, unknown>);
+      const differences: FieldDifference[] = [];
+      for (const fieldName of fieldsToCompare) {
+        const airtableValue = (record.fields as Record<string, unknown>)[fieldName] ?? null;
+        const supabaseValue = (supabaseRow as Record<string, unknown>)[fieldName] ?? null;
+        if (stableStringify(airtableValue) !== stableStringify(supabaseValue)) {
+          differences.push({ field: fieldName, airtableValue, supabaseValue });
+        }
+      }
+
+      if (differences.length) {
+        let lastModified: string | null = null;
+        if (table.lastModifiedField) {
+          const raw = (record.fields as Record<string, unknown>)[table.lastModifiedField];
+          lastModified = typeof raw === 'string' ? raw : null;
+        }
+        diffReports.push({
+          primaryKeyValue: String(pkValue),
+          lastModifiedTime: lastModified,
+          differences,
+        });
+      }
+    }
+
+    if (rowsToInsert.length) {
+      console.log(`  Found ${rowsToInsert.length} new Airtable record(s) to insert.`);
+      if (!args.dryRun) {
+        const chunkSize = 50;
+        for (let i = 0; i < rowsToInsert.length; i += chunkSize) {
+          const chunk = rowsToInsert.slice(i, i + chunkSize);
+          const { error: insertError } = await supabase.from(table.supabaseTable).insert(chunk);
+          if (insertError) {
+            throw new Error(`Supabase insert failed for table ${table.supabaseTable}: ${insertError.message}`);
+          }
+        }
+      } else {
+        console.log('  Dry run enabled – skipping inserts.');
+      }
+    } else {
+      console.log('  No new Airtable records to insert.');
+    }
+
+    if (diffReports.length) {
+      console.log('  Differences detected:');
+      console.log(groupDifferences(diffReports));
+    } else {
+      console.log('  No field-level differences detected.');
+    }
+
+    newState[table.supabaseTable] = { lastSyncedAt: new Date().toISOString() };
+    summaryLines.push(
+      `${label}: inserted ${rowsToInsert.length} new record(s); ${diffReports.length} record(s) with differences.`,
+    );
+  }
+
+  if (!args.dryRun) {
+    await saveState(args.statePath, newState);
+  } else {
+    console.log('\nDry run mode – state file not updated.');
+  }
+
+  if (summaryLines.length) {
+    console.log('\n=== Sync summary ===');
+    for (const line of summaryLines) {
+      console.log(`- ${line}`);
+    }
+  }
+}
+
+run().catch((error: unknown) => {
+  if (error && typeof error === 'object' && 'message' in error) {
+    console.error((error as { message: string }).message);
+  } else {
+    console.error(error);
+  }
+  process.exitCode = 1;
+});

--- a/client-new/tsconfig.json
+++ b/client-new/tsconfig.json
@@ -12,9 +12,9 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
-  "include": ["src"],
+  "include": ["src", "scripts"],
   "exclude": ["node_modules", "dist"]
 }
 


### PR DESCRIPTION
## Summary
- add a configurable Airtable → Supabase sync script with logging, diff reporting, and optional dry-run mode
- document configuration, environment variables, and usage examples for the new script
- expose npm helpers for running the sync, enable Node typings for the project scripts, and revert the charter constants import change per feedback

## Testing
- npm run typecheck *(fails: missing TABLE_COLUMNS/ROW_ACTIONS/TABLE_ACTIONS symbols in src/modules/charters/constants.ts after reverting the import as requested)*

------
https://chatgpt.com/codex/tasks/task_e_68caa65b1ae88321a03e7ede4f443713